### PR TITLE
only display current fy if data available

### DIFF
--- a/components/js/signal-timing.js
+++ b/components/js/signal-timing.js
@@ -360,10 +360,11 @@ function getDefaultYear() {
   var currentMonth = currentDate.getMonth() + 1;
   var currentYear = currentDate.getFullYear();
 
-  if (currentMonth < 10) {
-    selected_year = currentYear;
+  // Display data for the current fiscal year if available, otherwise default to previous year
+  if (currentMonth >= 10 && GROUPED_RETIMING_DATA["$" + currentYear + 1]) {
+    selected_year = currentYear + 1
   } else {
-    selected_year = currentYear + 1;
+    selected_year = currentYear;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5476,7 +5476,7 @@
       "dependencies": {
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         }


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/4140

Prevents page from breaking by displaying the current fiscal year only if data is available. Otherwise the page displays data for the previous fiscal year.

<img width="1263" alt="Screen Shot 2020-10-13 at 3 58 35 PM" src="https://user-images.githubusercontent.com/35410637/95915595-fc922f80-0d6c-11eb-97ba-97be4687bea6.png">
