### PR TITLE
Remove deprecated about.js config entry

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,8 +4,7 @@ module.exports = {
   context: path.resolve(__dirname, "webpackjs"),
   // webpack folder’s entry js — excluded from jekll’s build process.
   entry: {
-    micromobility: "./micromobility-data.js",
-    about: "./about.js"
+    micromobility: "./micromobility-data.js"
   },
   output: {
     // we’re going to put the generated file in the assets folder so jekyll will grab it.


### PR DESCRIPTION
@tillyw @mateoclarke I was getting a webpack build error from the missing `about.js` file. I removed it from the config and it built just fine. 