### PR TITLE
Add redirect to RideReport open data portal

### DIFF
--- a/_layouts/homepage-layout.html
+++ b/_layouts/homepage-layout.html
@@ -170,7 +170,7 @@
           <div class="row">
             <a
               class="nav-homepage col-md-4 col-xl-3 col-sm-6 p-1"
-              href="{{ site.baseurl }}/micromobility-data"
+              href="https://public.ridereport.com/austin"
             >
               <div class="col homepage-button homepage-button-row-3 p-2">
                 <h5>Shared Micromobility Data</h5>

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,9 @@
     to = "https://www.austinmobility.io/about"
     status = 301
     force = true
+    
+ [[redirects]]
+    from = "https://data.mobility.austin.gov/micromobility-data/"
+    to = "https://public.ridereport.com/austin"
+    status = 301
+    force = true


### PR DESCRIPTION
Related to https://github.com/cityofaustin/atd-data-tech/issues/8493

- Added redirect at Netlify config level. (this won't work as intended until the code is merged into `master`)
- Update link from homepage "Shared Micromobility Data" card to RideReport external link

![Screen Shot 2022-04-04 at 12 57 45 PM](https://user-images.githubusercontent.com/5697474/161603831-cc156c8a-1444-41ec-b422-34596cfb59d7.png)