### PR TITLE
Redirect old data-tracker route to...the data tracker

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -36,3 +36,7 @@ status = 301
 from = "/open-data"
 to = "https://data.austintexas.gov/browse?City-of-Austin_Department-=Austin+Transportation&limitTo=datasets"
 status = 301
+[[redirects]]
+from = "/data-tracker"
+to = "https://atd.knack.com/amd#home/"
+status = 301


### PR DESCRIPTION
@dianamartin flagged that users used to be able to get to the Data Tracker via https://data.mobility.austin.gov/data-tracker. 

I think I missed this redirect when we launched because we were redirecting with Javasrcipt, not Netlify :/

You can test this by clicking here: https://deploy-preview-403--austin-transportation.netlify.app/data-tracker