### PR TITLE
Add dark Signal Montior

### DIFF
--- a/page-settings/signal-monitor.js
+++ b/page-settings/signal-monitor.js
@@ -1,5 +1,5 @@
 import { FaExclamationTriangle, FaClock, FaPhone } from "react-icons/fa";
-import { TbTrafficLights } from "react-icons/tb";
+import { TbTrafficLightsOff } from "react-icons/tb";
 
 const COLORS = {
   red: "#c41213",
@@ -43,7 +43,7 @@ const OPERATION_STATES = [
     color: COLORS.black,
     featureProp: "operation_state",
     checked: true,
-    icon: TbTrafficLights,
+    icon: TbTrafficLightsOff,
   },
 ];
 

--- a/page-settings/signal-monitor.js
+++ b/page-settings/signal-monitor.js
@@ -1,9 +1,11 @@
 import { FaExclamationTriangle, FaClock, FaPhone } from "react-icons/fa";
+import { TbTrafficLights } from "react-icons/tb";
 
 const COLORS = {
   red: "#c41213",
   orange: "#f29900",
   blue: "#377eb8",
+  black: "#000000",
 };
 
 const OPERATION_STATES = [
@@ -34,6 +36,15 @@ const OPERATION_STATES = [
     checked: true,
     icon: FaPhone,
   },
+  {
+    key: "dark_signal",
+    value: "4",
+    label: "Dark",
+    color: COLORS.black,
+    featureProp: "operation_state",
+    checked: true,
+    icon: TbTrafficLights,
+  },
 ];
 
 export const SEARCH_SETTINGS = {
@@ -52,6 +63,8 @@ export const LAYER_STYLES = {
       OPERATION_STATES[0].color,
       "3",
       OPERATION_STATES[2].color,
+      "4",
+      OPERATION_STATES[3].color,
       // fallback
       "#ccc",
     ],


### PR DESCRIPTION
Specs in here: https://github.com/cityofaustin/atd-data-tech/issues/15212

This [PR](https://github.com/cityofaustin/atd-kits/pull/13) is adding an additional signal status (dark) to the [socrata backend](https://data.austintexas.gov/Transportation-and-Mobility/Traffic-Signals-Status/5zpr-dehc/data) of this page.

Steps to test:
- Currently, you have to run the code in the atd-kits PR in order to populate the dark signal that has been set for testing purposes at Cameron/Ferguson. The current airflow DAG runs every 5 minutes and will remove that dark signal from the dataset if you aren't quick enough.
- `npm run dev` and check the signal monitor for the dark signal.

Here's what it looks like:
<img width="918" alt="Screenshot 2024-01-12 at 1 12 15 PM" src="https://github.com/cityofaustin/atd-data-and-performance/assets/30810522/b200bc4e-092c-4138-a4e5-6aea58c5cd9c">

Popup:
<img width="358" alt="Screenshot 2024-01-12 at 1 19 04 PM" src="https://github.com/cityofaustin/atd-data-and-performance/assets/30810522/3f409a37-acf3-414c-a87a-9877b69813b4">

