### PR TITLE
Fix `next export` by disabling i18n

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  //i18n: {
-  //locales: ["en"],
-  //defaultLocale: "en",
-  //},
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -2,9 +2,9 @@
 const nextConfig = {
   reactStrictMode: true,
   //i18n: {
-    //locales: ["en"],
-    //defaultLocale: "en",
+  //locales: ["en"],
+  //defaultLocale: "en",
   //},
-};
+}
 
-module.exports = nextConfig;
+module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  i18n: {
-    locales: ["en"],
-    defaultLocale: "en",
-  },
+  //i18n: {
+    //locales: ["en"],
+    //defaultLocale: "en",
+  //},
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Please see: https://austininnovation.slack.com/archives/CHZE6BC6L/p1705094509036779.

Our `next export` step is not working because we have i18n turned on. Export wants to make static HTML, and it can't have dynamic text in that, of course.