### PR TITLE
updates dark signal symbology to x icon

### DIFF
--- a/page-settings/signal-monitor.js
+++ b/page-settings/signal-monitor.js
@@ -1,5 +1,4 @@
-import { FaExclamationTriangle, FaClock, FaPhone } from "react-icons/fa";
-import { TbTrafficLightsOff } from "react-icons/tb";
+import { FaExclamationTriangle, FaClock, FaPhone, FaTimes } from "react-icons/fa";
 
 const COLORS = {
   red: "#c41213",
@@ -43,7 +42,7 @@ const OPERATION_STATES = [
     color: COLORS.black,
     featureProp: "operation_state",
     checked: true,
-    icon: TbTrafficLightsOff,
+    icon: FaTimes,
   },
 ];
 


### PR DESCRIPTION
fixes https://github.com/cityofaustin/atd-data-tech/issues/15250

pretty straightforward update! I agree that the new symbology is more clear. in order for y'all to test it we just need a dark signal record in data tracker, i believe @Charlie-Henry and @ChristinaTremel are working on that! here's a preview of what it should look like.

<img width="1919" alt="Screenshot 2024-02-21 at 4 45 02 PM" src="https://github.com/cityofaustin/atd-data-and-performance/assets/35410637/2104e53c-bcf9-49cf-9685-acd3cde0602f">
