### PR TITLE
removes comm outages from signal monitor

### DIFF
--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -176,17 +176,15 @@ function MapList({
                   hasSelectedFeature={!!selectedFeature}
                   featureCounts={featureCounts}
                 />
-                {searchedGeojson.features.length ? <div className="px-3" style={{ overflowY: "scroll" }}>
+                <div className="px-3" style={{ overflowY: "scroll" }}>
                   <List
                     geojson={searchedGeojson}
                     mapRef={mapRef}
                     setSelectedFeature={setSelectedFeature}
                     ListItemContent={ListItemContent}
                   />
-                </div> :
-                  <div className="p-3">Signal system operating normally.</div>
-                }
-              </div> 
+                </div>
+              </div>
               {/* page info content */}
               {layout.info && isSmallScreen && (
                 <div className="px-3">

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -161,7 +161,7 @@ function MapList({
               )}
               {/* note the use of d-none (display: none) to hide elements. this avoids
               laborious re-renders */}
-              {searchedGeojson ? <div
+              {searchedGeojson.features.length ? <div
                 className={`d-flex flex-column ${(!layout.listSearch && "d-none") || ""
                   }`}
                 style={{ overflowY: "hidden" }}

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -161,7 +161,7 @@ function MapList({
               )}
               {/* note the use of d-none (display: none) to hide elements. this avoids
               laborious re-renders */}
-              {searchedGeojson.features.length ? <div
+              <div
                 className={`d-flex flex-column ${(!layout.listSearch && "d-none") || ""
                   }`}
                 style={{ overflowY: "hidden" }}
@@ -176,17 +176,17 @@ function MapList({
                   hasSelectedFeature={!!selectedFeature}
                   featureCounts={featureCounts}
                 />
-                <div className="px-3" style={{ overflowY: "scroll" }}>
+                {searchedGeojson.features.length ? <div className="px-3" style={{ overflowY: "scroll" }}>
                   <List
                     geojson={searchedGeojson}
                     mapRef={mapRef}
                     setSelectedFeature={setSelectedFeature}
                     ListItemContent={ListItemContent}
                   />
-                </div>
-              </div> :
-                <div className="px-3">Signal system operating normally.</div>
-              }
+                </div> :
+                  <div className="p-3">Signal system operating normally.</div>
+                }
+              </div> 
               {/* page info content */}
               {layout.info && isSmallScreen && (
                 <div className="px-3">

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -161,10 +161,9 @@ function MapList({
               )}
               {/* note the use of d-none (display: none) to hide elements. this avoids
               laborious re-renders */}
-              <div
-                className={`d-flex flex-column ${
-                  (!layout.listSearch && "d-none") || ""
-                }`}
+              {searchedGeojson ? <div
+                className={`d-flex flex-column ${(!layout.listSearch && "d-none") || ""
+                  }`}
                 style={{ overflowY: "hidden" }}
               >
                 <ListSearch
@@ -185,7 +184,9 @@ function MapList({
                     ListItemContent={ListItemContent}
                   />
                 </div>
-              </div>
+              </div> :
+                <div className="px-3">Signal system operating normally.</div>
+              }
               {/* page info content */}
               {layout.info && isSmallScreen && (
                 <div className="px-3">

--- a/page-settings/signal-monitor.js
+++ b/page-settings/signal-monitor.js
@@ -1,9 +1,8 @@
-import { FaExclamationTriangle, FaClock, FaPhone, FaTimes } from "react-icons/fa";
+import { FaExclamationTriangle, FaClock, FaTimes } from "react-icons/fa";
 
 const COLORS = {
   red: "#c41213",
   orange: "#f29900",
-  blue: "#377eb8",
   black: "#000000",
 };
 
@@ -25,15 +24,6 @@ const OPERATION_STATES = [
     featureProp: "operation_state",
     checked: true,
     icon: FaClock,
-  },
-  {
-    key: "comm_outage",
-    value: "3",
-    label: "Comm. issue",
-    color: COLORS.blue,
-    featureProp: "operation_state",
-    checked: true,
-    icon: FaPhone,
   },
   {
     key: "dark_signal",
@@ -62,8 +52,6 @@ export const LAYER_STYLES = {
       OPERATION_STATES[0].color,
       "3",
       OPERATION_STATES[2].color,
-      "4",
-      OPERATION_STATES[3].color,
       // fallback
       "#ccc",
     ],


### PR DESCRIPTION
fixes https://github.com/cityofaustin/atd-data-tech/issues/1585

[deploy preview for testing](https://deploy-preview-418--austin-transportation.netlify.app/signal-monitor)

This pr removes signals that have communication outages from the signal monitor. If all signals are operating properly visitors will see this screen (please ignore that fact that there are a couple of data points on the map):

<img width="1918" alt="Screenshot 2024-05-23 at 5 49 12 PM" src="https://github.com/cityofaustin/atd-data-and-performance/assets/35410637/381a69ba-cb39-430b-8538-3d8389ce0a29">

One suggestion I would make is maybe we should consider renaming the signal monitor? since it only displays signals that are not functioning properly maybe we should call it 'Signal Outage Monitor' or something like that (I'm not sure what the best term would be). That way it will be less confusing to come across it in cases when everything is functioning properly and see a blank map (which would be a little confusing to me).

As far as testing, I'm not sure how best to do that. @Charlie-Henry is it possible to temporarily alter or clear the data being fed into the dashboard so our signal folks can test? Devs can test by setting `searchedGeojson` to `null` but that's not the most elegant workaround!