### PR TITLE
Remove communication outages from signal monitor

### DIFF
--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -176,17 +176,15 @@ function MapList({
                   hasSelectedFeature={!!selectedFeature}
                   featureCounts={featureCounts}
                 />
-                {searchedGeojson.features.length ? <div className="px-3" style={{ overflowY: "scroll" }}>
+                <div className="px-3" style={{ overflowY: "scroll" }}>
                   <List
                     geojson={searchedGeojson}
                     mapRef={mapRef}
                     setSelectedFeature={setSelectedFeature}
                     ListItemContent={ListItemContent}
                   />
-                </div> :
-                  <div className="p-3">Signal system operating normally.</div>
-                }
-              </div> 
+                </div>
+              </div>
               {/* page info content */}
               {layout.info && isSmallScreen && (
                 <div className="px-3">

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -22,7 +22,6 @@ import {
   useCheckboxFilters,
   useSearchValue,
   useFeatureCounts,
-  useTotalFeatureCount,
 } from "../../utils/helpers";
 import typedefs from "../../typedefs";
 
@@ -50,6 +49,8 @@ import typedefs from "../../typedefs";
  * @property {string} featurePk - the object property that can be used to uniquely identify a geojson
  * feature. this property is used to avoid rendering the 'PopUpHoverContent' above an item which is
  * currently selected.
+ * @property {string} noFeaturesMessage - if there are no features to display in the Map, the list will show
+ * an alert with this message
  */
 
 function MapList({
@@ -74,8 +75,6 @@ function MapList({
   const mapRef = useRef();
 
   const featureCounts = useFeatureCounts({ geojson, filters });
-
-  const totalFeatureCount = useTotalFeatureCount(featureCounts);
 
   // applies checkbox filter state to geojson
   const filteredGeosjon = useCheckboxFilters({
@@ -183,7 +182,7 @@ function MapList({
                   featureCounts={featureCounts}
                 />
                 <div className="px-3" style={{ overflowY: "scroll" }}>
-                  {totalFeatureCount > 0 ? (
+                  {geojson?.features.length > 0 ? (
                     <List
                       geojson={searchedGeojson}
                       mapRef={mapRef}
@@ -265,6 +264,7 @@ MapList.propTypes = {
   title: PropTypes.string,
   getMapIcon: PropTypes.func,
   featurePk: PropTypes.string,
+  noFeaturesMessage: PropTypes.string,
 };
 
 export default MapList;

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -161,7 +161,7 @@ function MapList({
               )}
               {/* note the use of d-none (display: none) to hide elements. this avoids
               laborious re-renders */}
-              {searchedGeojson ? <div
+              {searchedGeojson.features.length ? <div
                 className={`d-flex flex-column ${(!layout.listSearch && "d-none") || ""
                   }`}
                 style={{ overflowY: "hidden" }}

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -191,7 +191,7 @@ function MapList({
                       ListItemContent={ListItemContent}
                     />
                   ) : (
-                    <Alert className="mt-3" variant={"success"}>
+                    <Alert className="mt-3" variant="success">
                       {noFeaturesMessage}
                     </Alert>
                   )}

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -161,7 +161,7 @@ function MapList({
               )}
               {/* note the use of d-none (display: none) to hide elements. this avoids
               laborious re-renders */}
-              {searchedGeojson.features.length ? <div
+              <div
                 className={`d-flex flex-column ${(!layout.listSearch && "d-none") || ""
                   }`}
                 style={{ overflowY: "hidden" }}
@@ -176,17 +176,17 @@ function MapList({
                   hasSelectedFeature={!!selectedFeature}
                   featureCounts={featureCounts}
                 />
-                <div className="px-3" style={{ overflowY: "scroll" }}>
+                {searchedGeojson.features.length ? <div className="px-3" style={{ overflowY: "scroll" }}>
                   <List
                     geojson={searchedGeojson}
                     mapRef={mapRef}
                     setSelectedFeature={setSelectedFeature}
                     ListItemContent={ListItemContent}
                   />
-                </div>
-              </div> :
-                <div className="px-3">Signal system operating normally.</div>
-              }
+                </div> :
+                  <div className="p-3">Signal system operating normally.</div>
+                }
+              </div> 
               {/* page info content */}
               {layout.info && isSmallScreen && (
                 <div className="px-3">

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -161,10 +161,9 @@ function MapList({
               )}
               {/* note the use of d-none (display: none) to hide elements. this avoids
               laborious re-renders */}
-              <div
-                className={`d-flex flex-column ${
-                  (!layout.listSearch && "d-none") || ""
-                }`}
+              {searchedGeojson ? <div
+                className={`d-flex flex-column ${(!layout.listSearch && "d-none") || ""
+                  }`}
                 style={{ overflowY: "hidden" }}
               >
                 <ListSearch
@@ -185,7 +184,9 @@ function MapList({
                     ListItemContent={ListItemContent}
                   />
                 </div>
-              </div>
+              </div> :
+                <div className="px-3">Signal system operating normally.</div>
+              }
               {/* page info content */}
               {layout.info && isSmallScreen && (
                 <div className="px-3">

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -6,6 +6,7 @@ import List from "../List";
 import ListSearch from "../ListSearch";
 import Map from "../Map";
 import Modal from "react-bootstrap/Modal";
+import Alert from "react-bootstrap/Alert";
 import Nav from "../Nav";
 import MapListMobileNav from "../MapListMobileNav";
 import PageTitle from "../PageTitle";
@@ -190,7 +191,9 @@ function MapList({
                       ListItemContent={ListItemContent}
                     />
                   ) : (
-                    <p>{noFeaturesMessage}</p>
+                    <Alert className="mt-3" variant={"success"}>
+                      {noFeaturesMessage}
+                    </Alert>
                   )}
                 </div>
               </div>

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -21,6 +21,7 @@ import {
   useCheckboxFilters,
   useSearchValue,
   useFeatureCounts,
+  useTotalFeatureCount,
 } from "../../utils/helpers";
 import typedefs from "../../typedefs";
 
@@ -64,6 +65,7 @@ function MapList({
   title,
   getMapIcon,
   featurePk,
+  noDataMessage,
 }) {
   const [filters, setFilters] = useState(filterSettings);
   const [searchValue, setSearchValue] = useState("");
@@ -71,6 +73,9 @@ function MapList({
   const mapRef = useRef();
 
   const featureCounts = useFeatureCounts({ geojson, filters });
+
+  const totalFeatureCount = useTotalFeatureCount(featureCounts);
+  console.log(totalFeatureCount);
 
   // applies checkbox filter state to geojson
   const filteredGeosjon = useCheckboxFilters({
@@ -89,13 +94,13 @@ function MapList({
     maxWidth: MAX_SMALL_SCREEN_WIDTH_PIXELS,
   });
 
-  // hids overflow on the document <body> while this component is mounted #noScrollBar
+  // hides overflow on the document <body> while this component is mounted #noScrollBar
   useHiddenOverflow();
 
   // hook which manages layout element display state
   const [layout, dispatchLayout] = useReducer(
     layoutReducer,
-    getInitialLayout(isSmallScreen)
+    getInitialLayout(isSmallScreen),
   );
 
   // triggers pan + zoom when a feature is selected from the list or map
@@ -162,8 +167,9 @@ function MapList({
               {/* note the use of d-none (display: none) to hide elements. this avoids
               laborious re-renders */}
               <div
-                className={`d-flex flex-column ${(!layout.listSearch && "d-none") || ""
-                  }`}
+                className={`d-flex flex-column ${
+                  (!layout.listSearch && "d-none") || ""
+                }`}
                 style={{ overflowY: "hidden" }}
               >
                 <ListSearch
@@ -177,12 +183,16 @@ function MapList({
                   featureCounts={featureCounts}
                 />
                 <div className="px-3" style={{ overflowY: "scroll" }}>
-                  <List
-                    geojson={searchedGeojson}
-                    mapRef={mapRef}
-                    setSelectedFeature={setSelectedFeature}
-                    ListItemContent={ListItemContent}
-                  />
+                  {totalFeatureCount > 0 ? (
+                    <List
+                      geojson={searchedGeojson}
+                      mapRef={mapRef}
+                      setSelectedFeature={setSelectedFeature}
+                      ListItemContent={ListItemContent}
+                    />
+                  ) : (
+                    <p>{noDataMessage}</p>
+                  )}
                 </div>
               </div>
               {/* page info content */}

--- a/components/MapList/index.js
+++ b/components/MapList/index.js
@@ -65,7 +65,7 @@ function MapList({
   title,
   getMapIcon,
   featurePk,
-  noDataMessage,
+  noFeaturesMessage,
 }) {
   const [filters, setFilters] = useState(filterSettings);
   const [searchValue, setSearchValue] = useState("");
@@ -75,7 +75,6 @@ function MapList({
   const featureCounts = useFeatureCounts({ geojson, filters });
 
   const totalFeatureCount = useTotalFeatureCount(featureCounts);
-  console.log(totalFeatureCount);
 
   // applies checkbox filter state to geojson
   const filteredGeosjon = useCheckboxFilters({
@@ -191,7 +190,7 @@ function MapList({
                       ListItemContent={ListItemContent}
                     />
                   ) : (
-                    <p>{noDataMessage}</p>
+                    <p>{noFeaturesMessage}</p>
                   )}
                 </div>
               </div>

--- a/page-settings/signal-monitor.js
+++ b/page-settings/signal-monitor.js
@@ -50,7 +50,7 @@ export const LAYER_STYLES = {
       OPERATION_STATES[1].color,
       "2",
       OPERATION_STATES[0].color,
-      "3",
+      "4",
       OPERATION_STATES[2].color,
       // fallback
       "#ccc",

--- a/page-settings/signal-monitor.js
+++ b/page-settings/signal-monitor.js
@@ -1,9 +1,8 @@
-import { FaExclamationTriangle, FaClock, FaPhone, FaTimes } from "react-icons/fa";
+import { FaExclamationTriangle, FaClock, FaTimes } from "react-icons/fa";
 
 const COLORS = {
   red: "#c41213",
   orange: "#f29900",
-  blue: "#377eb8",
   black: "#000000",
 };
 
@@ -25,15 +24,6 @@ const OPERATION_STATES = [
     featureProp: "operation_state",
     checked: true,
     icon: FaClock,
-  },
-  {
-    key: "comm_outage",
-    value: "3",
-    label: "Comm. issue",
-    color: COLORS.blue,
-    featureProp: "operation_state",
-    checked: true,
-    icon: FaPhone,
   },
   {
     key: "dark_signal",
@@ -62,8 +52,6 @@ export const LAYER_STYLES = {
       OPERATION_STATES[0].color,
       "3",
       OPERATION_STATES[2].color,
-      "4",
-      OPERATION_STATES[3].color,
       // fallback
       "#ccc",
     ],

--- a/pages/signal-evaluations.js
+++ b/pages/signal-evaluations.js
@@ -47,6 +47,7 @@ export default function SignalEvaluations() {
         title="Signal evaluations"
         getMapIcon={getMapIcon}
         featurePk="atd_location_id"
+        noFeaturesMessage="No signal evaluations found"
       />
     </>
   );

--- a/pages/signal-monitor.js
+++ b/pages/signal-monitor.js
@@ -45,7 +45,7 @@ export default function SignalMonitor() {
         title="Signal monitor"
         getMapIcon={getMapIcon}
         featurePk="signal_id"
-        noDataMessage="There is no data"
+        noFeaturesMessage="Signal system operating normally."
       />
     </>
   );

--- a/pages/signal-monitor.js
+++ b/pages/signal-monitor.js
@@ -20,9 +20,6 @@ export default function SignalMonitor() {
     error,
   } = useSocrata({ ...SIGNAL_STATUS_QUERY });
 
-  const darkSignalsLink =
-    "https://docs.google.com/spreadsheets/d/1lYsVNtpDF8TC0ud6Y_e4fTqN-gbifhZw4dqcE77v5RI/edit#gid=0";
-
   return (
     <>
       <PageHead
@@ -45,7 +42,7 @@ export default function SignalMonitor() {
         title="Signal monitor"
         getMapIcon={getMapIcon}
         featurePk="signal_id"
-        noFeaturesMessage="Signal system operating normally."
+        noFeaturesMessage="Signal system operating normally"
       />
     </>
   );

--- a/pages/signal-monitor.js
+++ b/pages/signal-monitor.js
@@ -45,6 +45,7 @@ export default function SignalMonitor() {
         title="Signal monitor"
         getMapIcon={getMapIcon}
         featurePk="signal_id"
+        noDataMessage="There is no data"
       />
     </>
   );

--- a/pages/traffic-cameras.js
+++ b/pages/traffic-cameras.js
@@ -55,6 +55,7 @@ export default function TrafficCameras() {
         layerStyles={LAYER_STYLES}
         title="Traffic cameras"
         featurePk="camera_id"
+        noFeaturesMessage="No traffic cameras found"
       />
     </>
   );

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -31,7 +31,7 @@ export const useSearchValue = ({ geojson, searchValue, featureProp }) =>
     filteredGeosjon.features = geojson.features.filter((feature) => {
       return stringIncludesCaseInsensitive(
         feature.properties[featureProp] || "",
-        searchValue
+        searchValue,
       );
     });
     return filteredGeosjon;
@@ -71,7 +71,7 @@ export const useFeatureCounts = ({ geojson, filters }) =>
     return filters.reduce((counts, filter) => {
       const key = filter.key;
       const matchingFeatures = geojson.features.filter(
-        (feature) => filter.value === feature.properties[filter.featureProp]
+        (feature) => filter.value === feature.properties[filter.featureProp],
       );
       counts[key] = matchingFeatures.length;
       return counts;
@@ -80,6 +80,12 @@ export const useFeatureCounts = ({ geojson, filters }) =>
     // and only once when we have a geojson
     // eslint-disable-next-line
   }, [geojson]);
+
+export const useTotalFeatureCount = (featureCounts) =>
+  useMemo(() => {
+    if (!featureCounts) return;
+    return Object.values(featureCounts).reduce((a, b) => a + b, 0);
+  }, [featureCounts]);
 
 /**
  * Applies overflow-hidden to the document <body> and removes it when the

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -81,16 +81,6 @@ export const useFeatureCounts = ({ geojson, filters }) =>
     // eslint-disable-next-line
   }, [geojson]);
 
-/**
- * Custom hook that sums the number of features that match the filters
- * @param { object } featureCounts - An object with one prop per filter in the format { filter.key: count }
- * @returns { Int } - sum of the counts
- */
-export const useTotalFeatureCount = (featureCounts) =>
-  useMemo(() => {
-    if (!featureCounts) return;
-    return Object.values(featureCounts).reduce((a, b) => a + b, 0);
-  }, [featureCounts]);
 
 /**
  * Applies overflow-hidden to the document <body> and removes it when the

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -81,6 +81,11 @@ export const useFeatureCounts = ({ geojson, filters }) =>
     // eslint-disable-next-line
   }, [geojson]);
 
+/**
+ * Custom hook that sums the number of features that match the filters
+ * @param { object } featureCounts - An object with one prop per filter in the format { filter.key: count }
+ * @returns { Int } - sum of the counts
+ */
 export const useTotalFeatureCount = (featureCounts) =>
   useMemo(() => {
     if (!featureCounts) return;

--- a/utils/queries.js
+++ b/utils/queries.js
@@ -62,6 +62,10 @@ export const SIGNAL_STATUS_QUERY = {
       key: "limit",
       value: "99999999",
     },
+    {
+      key: "where",
+      value: "operation_text!='Communication issue'"
+    }
   ],
 };
 


### PR DESCRIPTION
Tilly is on vacation so I [took over](https://github.com/cityofaustin/atd-data-and-performance/pull/418) wrapping up this issue https://github.com/cityofaustin/atd-data-tech/issues/1585

https://deploy-preview-419--austin-transportation.netlify.app/signal-monitor?

I reworked Tilly's original code a little by adding a hook to check how many results were returned, and displaying a message based on that instead of the length of the filtered geojson. 

Also liked John's suggesting of giving the message some styling, I used the success Alert component

<img width="1127" alt="Screenshot 2024-06-12 at 4 59 43 PM" src="https://github.com/cityofaustin/atd-data-and-performance/assets/12474808/ac22a32f-98c7-4521-b255-263a5df1b7cd">


Test by visiting the preview link and unchecking all the check boxes. Confirm the message does not appear. 


Locally you can get the success message to appear by changing the conditional to be if there are more than 0 features. Otherwise wait until the signal system is operating normally to see the message :) 

