### PR TITLE
identifies data and performance hub page language as english

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,7 +3,7 @@ import Document, { Html, Head, Main, NextScript } from "next/document";
 class AppDocument extends Document {
   render() {
     return (
-      <Html>
+      <Html lang="en">
         <Head>
           <link
             href="https://fonts.googleapis.com/css2?family=Inter&display=optional"


### PR DESCRIPTION
closes https://github.com/cityofaustin/atd-data-tech/issues/27600#issuecomment-4330201154

I ran the SiteImprove browser extension on this page and I am no longer seeing the 'A' priority issue. @amenity I was unable to sign in directly to SiteImprove using our credentials, but if you or Kate have access and are able to confirm, please do!

<img width="459" height="876" alt="Screenshot 2026-04-29 at 3 45 44 PM" src="https://github.com/user-attachments/assets/83b53b72-b51b-4200-b88c-17bf5a490302" />
