### PR TITLE
Update cctv redirect route

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Install dependencies
 npm install
 ```
 
+Create your local env file
+
+```
+cp env_template .env.local
+```
+
 Start the development server
 
 ```bash

--- a/components/pages/cameras/PopUpContent.js
+++ b/components/pages/cameras/PopUpContent.js
@@ -3,6 +3,9 @@ import FlexyInfo from "../../FlexyInfo";
 import { shortenLocationName } from "../../../utils/helpers";
 import Thumbnail from "../../Thumbnail";
 
+const CCTV_SERVICE_ENDPOINT =
+  process.env.NEXT_PUBLIC_CCTV_SERVICE_ENDPOINT || "http://10.66.2.214:5001";
+
 export default function PopUpContent({ feature }) {
   return (
     <Card className="h-100 nav-tile">
@@ -17,7 +20,7 @@ export default function PopUpContent({ feature }) {
           value={
             <small>
               <a
-                href={`http://10.66.2.214:5001/camera/${feature.properties.camera_id}`}
+                href={`${CCTV_SERVICE_ENDPOINT}/camera/${feature.properties.camera_id}`}
                 target="_blank"
                 rel="noreferrer"
               >

--- a/components/pages/cameras/PopUpContent.js
+++ b/components/pages/cameras/PopUpContent.js
@@ -4,7 +4,7 @@ import { shortenLocationName } from "../../../utils/helpers";
 import Thumbnail from "../../Thumbnail";
 
 const CCTV_SERVICE_ENDPOINT =
-  process.env.NEXT_PUBLIC_CCTV_SERVICE_ENDPOINT || "http://10.66.2.214:5001";
+  process.env.NEXT_PUBLIC_CCTV_SERVICE_ENDPOINT || "http://localhost:5001";
 
 export default function PopUpContent({ feature }) {
   return (

--- a/components/pages/cameras/PopUpContent.js
+++ b/components/pages/cameras/PopUpContent.js
@@ -17,7 +17,7 @@ export default function PopUpContent({ feature }) {
           value={
             <small>
               <a
-                href={`http://10.66.2.214:8000/?cam_id=${feature.properties.camera_id}`}
+                href={`http://10.66.2.214:5001/camera/${feature.properties.camera_id}`}
                 target="_blank"
                 rel="noreferrer"
               >

--- a/env_template
+++ b/env_template
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_CCTV_SERVICE_ENDPOINT="http://localhost:5001"


### PR DESCRIPTION
* https://github.com/cityofaustin/atd-data-tech/issues/29046

### Testing

1. Follow the instruction in https://github.com/cityofaustin/atd-cctv-service/pull/18 to get your local cctv-service app up and running

2. Create your env file

```
cp env_template .env.local
```

3. Start the app:

```shell
npm run dev
```

4. Visit the traffic cameras dashboard. Click on a camera point for a camera that is online, and use the **Restricted access** link to try to navigate to the cctv feed. 

<img width="353" height="302" alt="Screenshot 2026-06-29 at 2 46 25 PM" src="https://github.com/user-attachments/assets/6d1b11f0-4d5a-466a-8a85-a193fd51e7f8" />


You should be redirected to a `172.x` IP address that doesn't resolve. Nice!