### PR TITLE
Fixes linter errors in atd-data-and-performance

### DIFF
--- a/components/Thumbnail.js
+++ b/components/Thumbnail.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Image from "react-bootstrap/Image";
 
 const CCTV_IMAGE_BASE_URL = `https://cctv.austinmobility.io/image`;
@@ -10,12 +10,16 @@ const CCTV_IMAGE_BASE_URL = `https://cctv.austinmobility.io/image`;
 export default function Thumbnail({ cameraId }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
-  const src = `${CCTV_IMAGE_BASE_URL}/${cameraId}.jpg`;
-
-  useEffect(() => {
+  // Reset loading/error when cameraId changes during render (not in an effect)
+  // https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  const [prevCameraId, setPrevCameraId] = useState(cameraId);
+  if (cameraId !== prevCameraId) {
+    setPrevCameraId(cameraId);
     setLoading(true);
     setError(false);
-  }, [cameraId]);
+  }
+
+  const src = `${CCTV_IMAGE_BASE_URL}/${cameraId}.jpg`;
 
   return (
     <a

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "npm run lint && next build",
     "start": "next start",
     "lint": "eslint ."
   },

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,7 +3,7 @@ import Document, { Html, Head, Main, NextScript } from "next/document";
 class AppDocument extends Document {
   render() {
     return (
-      <Html lang="en">
+      <Html lang="en" data-scroll-behavior="smooth">
         <Head>
           <link
             href="https://fonts.googleapis.com/css2?family=Inter&display=optional"

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useSyncExternalStore } from "react";
 import { Marker } from "react-map-gl/maplibre";
 import {
   LAYER_STYLE_DEFAULT,
@@ -76,10 +76,7 @@ export const useFeatureCounts = ({ geojson, filters }) =>
       counts[key] = matchingFeatures.length;
       return counts;
     }, {});
-    // we don't want to render on `filter` change—these counts are calc'd once and
-    // and only once when we have a geojson
-    // eslint-disable-next-line
-  }, [geojson]);
+  }, [geojson, filters]);
 
 /**
  * Applies overflow-hidden to the document <body> and removes it when the
@@ -97,16 +94,17 @@ export const useHiddenOverflow = () => {
  * to control rendering of popup events on touch
  * @returns {bool} - if the device is touch-enabled
  */
-export const useIsTouchDevice = () => {
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
-  useEffect(() => {
-    if ("ontouchstart" in window) {
-      /* browser with Touch Events running on touch-capable device */
-      setIsTouchDevice(true);
-    }
-  }, []);
-  return isTouchDevice;
-};
+const emptySubscribe = () => () => {};
+const getIsTouchDevice = () =>
+  typeof window !== "undefined" && "ontouchstart" in window;
+const getIsTouchDeviceServerSnapshot = () => false;
+
+export const useIsTouchDevice = () =>
+  useSyncExternalStore(
+    emptySubscribe,
+    getIsTouchDevice,
+    getIsTouchDeviceServerSnapshot
+  );
 
 /**
  * Generates MapGL icon <Markers> which will be overlayed on top of map features.


### PR DESCRIPTION
## Associated issues
Relates to https://github.com/cityofaustin/atd-data-tech/issues/29608

Follow-up to https://github.com/cityofaustin/atd-data-and-performance/pull/446 — these are the React Compiler / Next 16 lint errors that started failing after we switched from `next lint` to the ESLint CLI.

Here are the 2 main linter errors and a little bit of info:

**`react-hooks/set-state-in-effect`**: Calling `setState` inside `useEffect` (ex: syncing props to state, or detecting browser capabilities on mount) causes an extra render after paint. We should prefer deriving state, adjusting during render, or a store subscription. ([more info](https://react.dev/learn/you-might-not-need-an-effect))

**`react-hooks/preserve-manual-memoization`**: Your `useMemo` / `useCallback` dependency list doesn’t match what the Compiler infers (ex: the memo closed over `filters` but only listed `[geojson]`). Manual memo must stay consistent so the Compiler can preserve it. ([more info](https://react.dev/reference/eslint-plugin-react-hooks/lints/preserve-manual-memoization))

## Testing

**URL to test:**
https://deploy-preview-447--austin-transportation.netlify.app

**Steps to test:**

### Traffic cameras (`/traffic-cameras`)
- [ ] Map + list load cameras on first visit
- [ ] Click a camera: popup shows thumbnail; image loads (or fails gracefully)
- [ ] Switch between cameras / open another popup: thumbnail resets and loads the new image
- [ ] Toggle status filters: counts update; map/list filter correctly
- [ ] Search by camera name still works

### Signal monitor / evaluations (MapList + touch)
- [ ] Desktop: hover popups still work as before
- [ ] Touch device (or DevTools device mode): map popup behavior still works without regressions

### Navigation / console
- [ ] Navigate between pages (home, traffic cameras, signal monitor): no `scroll-behavior: smooth` / missing `data-scroll-behavior` console warning

### Lint / build
- [ ] `npm run lint` passes with no errors
- [ ] `npm run build` runs lint then build, and fails if lint fails

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved (n/a — lint/tech debt)